### PR TITLE
Fix shop traps

### DIFF
--- a/SWR_AP_Client/APCallBacks.cpp
+++ b/SWR_AP_Client/APCallBacks.cpp
@@ -123,12 +123,13 @@ namespace SWRGame
 			if (wattoShopLocationToOffset.contains(curLocId))
 			{
 				SWR_PodPartEntry* curEntry = &apShopData.entries[wattoShopLocationToOffset[curLocId]];
-				wattoShopEntries.push_back({ 
+				wattoShopEntries[curLocId] = { 
 					(AP_ItemType)itemCopy.flags,
 					std::format("{} [{}]", itemCopy.itemName.c_str(), itemCopy.playerName.c_str()),
 					wattoShopLocationToOffset[curLocId]
-					});
-				curEntry->displayText = (char*)wattoShopEntries.back().displayName.c_str();
+					};
+
+				curEntry->displayText = (char*)wattoShopEntries[curLocId].displayName.c_str();
 				if (itemTable.contains(curItemId))
 				{
 					ItemInfo curItem = itemTable[curItemId];

--- a/SWR_AP_Client/APCallbacks.h
+++ b/SWR_AP_Client/APCallbacks.h
@@ -11,7 +11,7 @@ namespace SWRGame
 	extern AP_ServerInfo serverInfo;
 	extern void Log(const char* format, ...);
 
-	std::vector<AP_WattoEntry> wattoShopEntries;
+	std::map<int, AP_WattoEntry> wattoShopEntries;
 	extern int queuedDeaths;
 	extern std::vector <QueuedItem> itemQueue;
 	extern void QueueNotifyMsg(std::string _msg);

--- a/SWR_AP_Client/APCallbacks.h
+++ b/SWR_AP_Client/APCallbacks.h
@@ -15,6 +15,8 @@ namespace SWRGame
 	extern int queuedDeaths;
 	extern std::vector <QueuedItem> itemQueue;
 	extern void QueueNotifyMsg(std::string _msg);
+	extern CourseUnlockMode courseUnlockMode;
+	extern bool progressiveCircuits;
 	extern bool invitationalCircuitPass;
 	extern bool shuffledCourseUnlocks;
 	extern float aiModifier;
@@ -34,6 +36,7 @@ namespace SWRGame
 	void QueueDeath();
 	void ProcessMessages();
 
+	void SetProgressiveCircuits(int value);
 	void SetStartingRacers(int value);
 	void SetDisablePartDamage(int value);
 	void SetCourseUnlockMode(int value);

--- a/SWR_AP_Client/Draw.cpp
+++ b/SWR_AP_Client/Draw.cpp
@@ -55,11 +55,12 @@ namespace SWRGame
 	AP_WattoEntry* GetItemEntry()
 	{
 		int index = GetShopItemOffset();
-		for (int i = 0; i < wattoShopEntries.size(); i++)
+
+		for (auto offsetMapping : wattoShopLocationToOffset)
 		{
-			cachedEntry = wattoShopEntries[i];
-			if (cachedEntry.tableOffset == index)
-				return &cachedEntry;
+			if (index == offsetMapping.second)
+				if (wattoShopEntries.contains(offsetMapping.first))
+					return &wattoShopEntries[offsetMapping.first];
 		}
 
 		return nullptr;

--- a/SWR_AP_Client/Draw.h
+++ b/SWR_AP_Client/Draw.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Enums.h"
 #include "Structs.h"
+#include <map>
 
 typedef void(__cdecl* _WriteText)(short xPos, short yPos, int r, int g, int b, int a, const char* text, int unk_00, int unk_01);
 typedef void(__cdecl* _DrawStats)(void* obj, float x, float y);
@@ -23,7 +24,7 @@ namespace SWRGame
 	extern bool modifierControl;
 	extern SWR_PodPartTable apShopData;
 	extern int GetShopItemOffset();
-	extern std::vector<AP_WattoEntry> wattoShopEntries;
+	extern std::map<int, AP_WattoEntry> wattoShopEntries;
 	extern void Log(const char* format, ...);
 	extern _DrawStats DrawStats;
 	extern bool __fastcall isItemPodPart();

--- a/SWR_AP_Client/Enums.h
+++ b/SWR_AP_Client/Enums.h
@@ -86,9 +86,10 @@ enum SWRTextAlign
 
 enum AP_ItemType : int
 {
-	Filler = 0,
-	Progression = 1,
-	Useful = 2
+	Filler      = 0x00,
+	Progression = 0x01,
+	Useful      = 0x02,
+	Trap        = 0x04
 };
 
 enum SWRTextColor : int
@@ -102,4 +103,11 @@ enum SWRTextColor : int
 	AP_ProgressionItem = 0xAF99EFFF,
 	AP_UsefulItem      = 0x6D8BE8FF,
 	AP_FillerItem      = 0x00EEEEFF
+};
+
+enum CourseUnlockMode : int
+{
+	CircuitPassNoInv = 0,
+	CircuitPassInvitational = 1,
+	Shuffle = 2
 };

--- a/SWR_AP_Client/SWR.cpp
+++ b/SWR_AP_Client/SWR.cpp
@@ -567,7 +567,6 @@ namespace SWRGame
 		AP_RegisterSlotDataIntCallback("AutoHintShop", &SetAutoHintShop);
 		AP_RegisterSlotDataIntCallback("DeathLinkAmnesty", &SetDeathLinkAmnesty);
 		AP_RegisterSlotDataMapIntIntCallback("Courses", &SetCourses);
-
 		AP_Start();
 	}
 

--- a/SWR_AP_Client/SWR.h
+++ b/SWR_AP_Client/SWR.h
@@ -64,6 +64,8 @@ namespace SWRGame
 	std::string versionString = "";
 	uint64_t partialSeed = 0;
 
+	CourseUnlockMode courseUnlockMode;
+	bool progressiveCircuits = false;
 	bool invitationalCircuitPass = false;
 	bool shuffledCourseUnlocks = false;
 	bool hintShop = false;


### PR DESCRIPTION
Fixes issue #8 

- Displays randomized tempting items over ice traps
- Reworks `RecvLocationInfo` callback and caches shop info in a `std::map` object. 